### PR TITLE
feat: add namespace override support to Helm chart

### DIFF
--- a/charts/localstack/templates/_helpers.tpl
+++ b/charts/localstack/templates/_helpers.tpl
@@ -24,6 +24,19 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a default namespace for the app.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If a namespace override is provided, it will be used as the namespace.
+*/}}
+{{- define "localstack.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Release.Namespace | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "localstack.chart" -}}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "localstack.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "localstack.namespace" . }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
   annotations:

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -18,6 +18,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 ## @param extraDeploy Extra objects to deploy (value evaluated as a template)
 ##


### PR DESCRIPTION
## Motivation
Extended the Helm chart to allow for a namespace override via the new `namespaceOverride` value. This ensures that a custom namespace can be specified and used, otherwise defaults to the release namespace. This update enhances deployment flexibility in different Kubernetes environments

## Changes
add `namespaceOverride` to Values
